### PR TITLE
Logo redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 .idea/
+.vscode/
 /node_modules
 /.pnp
 .pnp.js

--- a/src/helpers/checkUserRole.js
+++ b/src/helpers/checkUserRole.js
@@ -1,0 +1,14 @@
+import store from '../redux/reducers';
+import { ADMIN, USER } from './types';
+
+export const checkUserRole = () => {
+  const user = store.getState().user;
+
+  if (!user.roles || !user.roles.length) {
+    return null;
+  } else if (user.roles.includes(ADMIN)) {
+    return ADMIN;
+  } else if(user.roles.includes(USER)) {
+    return USER;
+  }
+};

--- a/src/layouts/Main/components/Topbar/Topbar.js
+++ b/src/layouts/Main/components/Topbar/Topbar.js
@@ -9,6 +9,8 @@ import InputIcon from '@material-ui/icons/Input';
 import { setCurrentUser } from '../../../../redux/authReducer';
 import { connect } from 'react-redux';
 import { clearTickets } from '../../../../redux/ticketsReducer';
+import { checkUserRole } from 'helpers/checkUserRole';
+import { USER, ADMIN } from 'helpers/types';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -34,7 +36,6 @@ const Topbar = props => {
 
   //TODO Find better solution to get out with staticContext Warning
   delete rest.staticContext;
-
   const classes = useStyles();
 
   const handleSignOut = event => {
@@ -49,10 +50,23 @@ const Topbar = props => {
     history.push('/sign-in');
   };
 
+  const determineHomepage = () => {
+    const role = checkUserRole();
+
+    switch (role) {
+      case ADMIN:
+        return '/dashboard';
+      case USER:
+        return '/account';
+      default:
+        return '/';
+    }
+  }
+
   return (
     <AppBar {...rest} className={clsx(classes.root, className)}>
       <Toolbar>
-        <RouterLink to="/">
+        <RouterLink to={determineHomepage}>
           <img alt="Logo" src="/images/logos/logo--white.svg" />
         </RouterLink>
         <div className={classes.flexGrow} />

--- a/src/layouts/Minimal/components/Topbar/Topbar.js
+++ b/src/layouts/Minimal/components/Topbar/Topbar.js
@@ -4,6 +4,8 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import { AppBar, Toolbar } from '@material-ui/core';
+import { checkUserRole } from 'helpers/checkUserRole';
+import { USER, ADMIN } from 'helpers/types';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -16,6 +18,19 @@ const Topbar = props => {
 
   const classes = useStyles();
 
+  const determineHomepage = () => {
+    const role = checkUserRole();
+
+    switch (role) {
+      case ADMIN:
+        return '/dashboard';
+      case USER:
+        return '/account';
+      default:
+        return '/';
+    }
+  }
+
   return (
     <AppBar
       {...rest}
@@ -23,7 +38,7 @@ const Topbar = props => {
       color="primary"
       position="fixed">
       <Toolbar>
-        <RouterLink to="/dashboard">
+        <RouterLink to={determineHomepage}>
           <img alt="Logo" src="/images/logos/logo--white.svg" />
         </RouterLink>
       </Toolbar>


### PR DESCRIPTION
Closes #41 

Redirect to corresponding url for each user role after clicking logo

After clicking logo, now user is redirected to following paths:
Admin -> `/dashboard`
User -> `/account`
Not logged in user -> `/sign-in`